### PR TITLE
Add ogr as a dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,10 @@ setup_requires =
     setuptools_scm_git_archive
 install_requires =
     click
-    tabulate
-    python-gitlab
+    ogr
     pygithub
+    python-gitlab
+    tabulate
 
 # [options.packages.find]
 # exclude =


### PR DESCRIPTION
Because it is.

Also: sort the list of dependencies to ease skimming through them.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>